### PR TITLE
Add a web-ready minified version of the source

### DIFF
--- a/arsinh-js-0.0.0.min.js
+++ b/arsinh-js-0.0.0.min.js
@@ -1,0 +1,1 @@
+function arsinh(t){return Math.log(t+Math.sqrt(t*t+1))};


### PR DESCRIPTION
I want to be able to use this on my website without downloading a bunch of unnecessary cruft. I can safely assume that others feel the same, especially my website's frequent visitors who are essentially getting their bandwidth stolen 28 bytes at a time by not providing a minified version of this library. 

Thanks, Obama. 
